### PR TITLE
Systemd timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,13 @@ then press i to start the insert mode and paste this in the last of the editor:
 and then save it by pressing esc then typing :wq and hitting enter.
 this cron will run the script twice everyday (at 1:00 & 13:00). and you can see the backup_log.log for crontab logs.
 For adjusting the cron according you your need, you can have a look at [here](https://docs.acquia.com/article/cron-time-string-format).
+
+## systemd service
+Alternatively, you can use systemd timer instead of cron:
+```
+mkdir -vp ~/.config/systemd/user/
+cp systemd/* ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now GBackup.timer
+```
+Please read systemd.time(7), systemd.timer(5) for details.

--- a/systemd/GBackup.service
+++ b/systemd/GBackup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Backup to Google Drive
+
+[Service]
+Type=simple
+ExecStart=/root/backup_gdrive.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/GBackup.timer
+++ b/systemd/GBackup.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run GBackup every day at 01:00 and 13:00
+
+[Timer]
+OnCalendar=*-*-* 01,13:00:00
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Timers can be used as an alternative to Cron for automatic backups. I added a very basic configuration and instructions of how to enable systemd timers for your project.